### PR TITLE
Typo in package.xml

### DIFF
--- a/ros2/src/launchers/package.xml
+++ b/ros2/src/launchers/package.xml
@@ -12,7 +12,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
-  <exec_depend>topics</exec_depend
+  <exec_depend>topics</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Faltaba «>» en línea 15.